### PR TITLE
Fix CI builds on Github Actions

### DIFF
--- a/.github/workflows/Hamburger_Build.yml
+++ b/.github/workflows/Hamburger_Build.yml
@@ -18,10 +18,9 @@ on:
     paths:
       - '*'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '*'
-    branches:
-      - master
 
 env:
   PLUG: Hamburger

--- a/.github/workflows/Hamburger_Build.yml
+++ b/.github/workflows/Hamburger_Build.yml
@@ -238,7 +238,7 @@ jobs:
         mv "${{matrix.folder}}/${{env.PLUG}}.clap" "./gh_artifacts/Manual Install/"
         mv "${{env.PLUG}} Installer.pkg" "./gh_artifacts"
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{env.PLUG}} ${{ matrix.name }}
         path: "./gh_artifacts"

--- a/.github/workflows/Hamburger_Build.yml
+++ b/.github/workflows/Hamburger_Build.yml
@@ -43,7 +43,7 @@ jobs:
           }
         - {
             name: "Linux (x86_64)",
-            os: ubuntu-20.04,
+            os: ubuntu-22.04,
             compiler: "Unix Makefiles",
             folder: "build_linux"
           }


### PR DESCRIPTION
# Summary
- Bump upload-artifact@v4 in CI
- Remove branch restriction from PRs, to have CI run on pull requests
- Bump Linux runner to Ubuntu 22.04

## Test Plan
Rerun CI on new commits, merge when all platforms pass builds.